### PR TITLE
Update python's manifest to account for new swift bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ dist*
 *.egg-info
 .coverage
 coverage.info
-.DS_store
+**/.DS_store
 htmlcov
 .vscode/
 xcuserdata/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ recursive-include src *
 
 prune .github
 prune docs
+exclude **/.DS_Store
 exclude .gitmodules
 recursive-exclude src *.git
 exclude .readthedocs.yml
@@ -25,3 +26,5 @@ prune maintainers
 prune tests
 prune src/deps/pybind11/tools/clang
 prune src/deps/rapidjson/thirdparty
+prune src/spm-build
+prune src/swift-opentimelineio


### PR DESCRIPTION
This PR updates the python manifest so that the sdist and check_manifest tools succeed when packaging for pypi.